### PR TITLE
fix(Starter.cpp): format of MOVE actions

### DIFF
--- a/starterAIs/Starter.cpp
+++ b/starterAIs/Starter.cpp
@@ -111,7 +111,7 @@ int main()
                 int amount = 0; // TODO: pick amount of units to move
                 Tile target; // TODO: pick a destination
                 ostringstream action;
-                    action << "MOVE " << amount << " " << tile << target;
+                    action << "MOVE " << amount << " " << tile << " " << target;
                     actions.emplace_back(
                         action.str()
                     );


### PR DESCRIPTION
MOVE action requires `units_amount` `fromTile` `toTile` delimited by space.
The format is fixed so that `tile` and `target` can be spaced.