### PR TITLE
Fix spawn cost overflow

### DIFF
--- a/src/main/java/com/codingame/game/Game.java
+++ b/src/main/java/com/codingame/game/Game.java
@@ -684,7 +684,7 @@ public class Game {
                         throw new GameException(
                             String.format("tried to spawn %d units at (%d, %d), into a recycler", spawn.getAmount(), target.x, target.y)
                         );
-                    } else if (player.money < spawnCost) {
+                    } else if (player.money / Config.COST_UNIT < spawn.getAmount()) {
                         throw new GameException(
                             String.format("tried to spawn %d units at (%d, %d), but has not enough matter", spawn.getAmount(), target.x, target.y)
                         );


### PR DESCRIPTION
Hey !
If a player try to spawn an amount of units >= 214748365, an overflow occurs because of a multiplication by 10, causing the variable to overflow and become negative.
Fixes #6 